### PR TITLE
add ACR build support

### DIFF
--- a/.docker/prod-alpine.Dockerfile
+++ b/.docker/prod-alpine.Dockerfile
@@ -1,6 +1,6 @@
-ARG VERSION=latest-alpine3.20
+ARG VERSION
 
-FROM alpine:3.20 AS build
+FROM alpine:${VERSION} AS build
 COPY . /source
 RUN sh /source/.github/install-openvas-smb-dependencies-alpine.sh
  
@@ -10,7 +10,7 @@ RUN cp .github/alpine-patches/*.patch . && git apply *.patch
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM alpine:3.20
+FROM alpine:${VERSION}
 
 RUN apk update && apk upgrade && \
   apk add --no-cache gnutls \

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-.docker
 changelog
 build

--- a/acr-task.yaml
+++ b/acr-task.yaml
@@ -1,0 +1,22 @@
+{{ $alpineVersion := "3.20" }}
+version: v1.1.0
+stepTimeout: 3600
+env:
+  - DOCKER_BUILDKIT=1
+steps:
+  - id: build-amd64
+    build: --tag {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr-amd64 -f .docker/prod-alpine.Dockerfile --platform=linux/amd64 --build-arg VERSION={{ $alpineVersion }} .
+    when: ["-"]
+  - id: build-arm64
+    build: --tag {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr-arm64 -f .docker/prod-alpine.Dockerfile --platform=linux/arm64 --build-arg VERSION={{ $alpineVersion }} .
+    when: ["-"]
+  - push:
+    - {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr-amd64
+    - {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr-arm64
+    when: ["build-amd64", "build-arm64"]
+  - cmd: >
+      docker manifest create
+      {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr
+      {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr-amd64
+      {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr-arm64
+  - cmd: docker manifest push --purge {{ .Run.Registry }}/openvas-smb:alpine{{ $alpineVersion }}-acr


### PR DESCRIPTION
* add acr-task.yaml with build spec for multiarch builds
* remove .docker from .dockerignore -- dockerignore'd files seem to be invisible to acr agents, and we need the dockerfile for the build
* fix dockerfile VERSION arg to actually use the version number during the build